### PR TITLE
Update to use `prop-types`, ES6 class and latest deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pinboard",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "Responsive Pinterest-style layouts for React.js",
   "main": "lib/ReactPinboard.js",
   "files": [
@@ -31,16 +31,17 @@
   },
   "homepage": "https://github.com/apartmenttherapy/react-pinboard#readme",
   "dependencies": {
-    "lodash.debounce": "^4.0.5"
+    "lodash.debounce": "^4.0.8",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "babel-cli": "^6.7.5",
-    "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "eslint": "^2.7.0",
-    "eslint-plugin-react": "^4.3.0",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "babel-cli": "^6.24.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "eslint": "^3.19.0",
+    "eslint-plugin-react": "^7.0.1",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   }
 }


### PR DESCRIPTION
Maintenance updates:
1. Use `prop-types` lib instead of `React.PropTypes`
2. Use a class instead of `React.createClass`
3. Update dependencies to latest versions

Warnings for 1 and 2 should no longer show.